### PR TITLE
fixes in path to polyglot import file and npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rosetta
 
-The goal of Rosetta is to link your own I18N solution to SUI-* components. 
+The goal of Rosetta is to link your own I18N solution to SUI-* components.
 
 The main idea behind Rosetta is that I18N is not a ReactJS problem, thus, one should not add another component solely dedicated to translation. Instead, literals within components will be the argument of a function such as the following:
 
@@ -40,7 +40,7 @@ Rosetta will also work perfectly with AngularJS or Backbone. All you need to do 
 
 ```javascript
 import i18n, {CHANGE_TRANSLATION_EVENT, rosetta} from '@schibstedspain/rosetta';
-import polyglot from '@schibstedspain/rosetta/adapters/polyglot';
+import polyglot from '@schibstedspain/rosetta/lib/adapters/polyglot';
 
 i18n.adapter = polyglot;
 i18n.translations = {
@@ -56,7 +56,7 @@ From now on, Rosetta will use Polyglot to translate your literals anywhere in yo
 
 Anytime part of your code changes dictionaries, `I18N` will emit a **translations** event, allowing you to react accordingly, in case you need to take an additional action(s) when there’s a change of language in your app.
 
-### Creating your own adapters 
+### Creating your own adapters
 
 An adapter is just a Javascript object with two obligatory attributes:
 
@@ -75,7 +75,7 @@ In order to simplify the use of Rosetta in combination with React, a decorator i
  import React from 'react';
  import {rosetta} from '@schibstedspain/rosetta';
 
- @rosetta //=> This decorator allows us to update all components if there is a change of language 
+ @rosetta //=> This decorator allows us to update all components if there is a change of language
  class App extends React.Component {
     render(){
         <div></div>
@@ -87,7 +87,7 @@ In order to simplify the use of Rosetta in combination with React, a decorator i
  // index.js
 
  import i18n from '@schibstedspain/rosetta';
- import polyglot from '../src/adapters/polyglot';
+ import polyglot from '@schibstedspain/rosetta/lib/adapters/polyglot';
  import App from '../app';
 
  const spanish = {


### PR DESCRIPTION
- Minor fixes in path to polyglot file
- just wondering if a link to npm node module is missing here:
`@schibstedspain/rosetta/lib/adapters/polyglot';`