### PR TITLE
Removed deprecated rosetta methods

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,6 +1,5 @@
 import {EventEmitter} from 'events';
 import DefaultAdapter from './adapters/default';
-import {warn} from './console';
 import * as decorator from './decorator';
 
 export const CHANGE_TRANSLATION_EVENT = 'translations';
@@ -34,23 +33,6 @@ export default class Rosetta extends EventEmitter {
     this._languages = languages;
   }
 
-  set translations (dicc) {
-    warn('Rosetta#translations DEPRECATED');
-    this.translator.translations = dicc;
-    this.emit(CHANGE_TRANSLATION_EVENT, dicc);
-  }
-
-  setTranslationsSilent(dicc, culture){
-    warn('Rosetta#setTranslationsSilent DEPRECATED');
-    this._culture = culture;
-    this.translator.translations = dicc;
-  }
-
-  get locale() {
-    warn('Rosetta#locale DEPRECATED');
-    return this.translator.locale;
-  }
-
   t(key, values) {
     return this.translator.translate(key, values);
   }
@@ -64,5 +46,4 @@ export default class Rosetta extends EventEmitter {
   addToContext(Component, languages){
     return decorator.rosetta(this, languages)(Component);
   }
-
 }

--- a/test/adapters/polyglotSpec.js
+++ b/test/adapters/polyglotSpec.js
@@ -7,31 +7,39 @@ import Polyglot from '../../src/adapters/polyglot';
 // Borrowed from https://github.com/airbnb/polyglot.js/blob/master/test/main.coffee
 
 const phrases = {
-  'hello': 'Hello',
-  'hi_name_welcome_to_place': 'Hi, %{name}, welcome to %{place}!',
-  'name_your_name_is_name': '%{name}, your name is %{name}!',
-  'empty_string': ''
+  'en-GB': {
+    'hello': 'Hello',
+    'hi_name_welcome_to_place': 'Hi, %{name}, welcome to %{place}!',
+    'name_your_name_is_name': '%{name}, your name is %{name}!',
+    'empty_string': ''
+  }
 };
 
 const nestedPhrases = {
-  'nav': {
-    'presentations': 'Presentations',
-    'hi_user': 'Hi, %{user}.',
-    'cta': {
-      'join_now': 'Join now!'
-    }
-  },
-  'header.sign_in': 'Sign In'
+  'en-GB': {
+    'nav': {
+      'presentations': 'Presentations',
+      'hi_user': 'Hi, %{user}.',
+      'cta': {
+        'join_now': 'Join now!'
+      }
+    },
+    'header.sign_in': 'Sign In'
+  }
 };
 
 const pluralizePhrases = {
-  'count_name': '%{smart_count} Name |||| %{smart_count} Names'
+  'en-GB': {
+    'count_name': '%{smart_count} Name |||| %{smart_count} Names'
+  }
 };
 
 const urlTokens = {
-  'rent': 'Alquiler',
-  'house': 'Casa',
-  'elevator': 'ascensor'
+  'es-ES': {
+    'rent': 'Alquiler',
+    'house': 'Casa',
+    'elevator': 'ascensor'
+  }
 };
 
 describe('I18N with polyglot adapter', () => {
@@ -40,7 +48,10 @@ describe('I18N with polyglot adapter', () => {
   afterEach( () => i18n = null);
 
   describe('translate', () => {
-    beforeEach(() => i18n.translations = phrases);
+    beforeEach(() => {
+      i18n.languages = phrases;
+      i18n.culture = 'en-GB';
+    });
 
     it('should translate a simple string', () => expect(i18n.t('hello')).to.eql('Hello'));
 
@@ -84,8 +95,14 @@ describe('I18N with polyglot adapter', () => {
     });
 
     describe('nested phrase objects', () => {
-      beforeEach(() => i18n.translations = nestedPhrases);
-      afterEach(() => i18n.translations = phrases);
+      beforeEach(() => {
+        i18n.languages = nestedPhrases;
+        i18n.culture = 'en-GB';
+      });
+      afterEach(() => {
+        i18n.languages = phrases;
+        i18n.culture = 'en-GB';
+      });
       it('should translate a simple string', () => {
         expect(i18n.t('nav.presentations')).to.eql('Presentations');
         expect(i18n.t('nav.hi_user', {user: 'Raph'})).to.eql('Hi, Raph.');
@@ -96,12 +113,12 @@ describe('I18N with polyglot adapter', () => {
 
     describe('pluralize', () => {
       beforeEach(() => {
-        i18n.adapter.locale = 'es';
-        i18n.translations = pluralizePhrases;
+        i18n.languages = pluralizePhrases;
+        i18n.culture = 'en-GB';
       });
       afterEach(() => {
-        i18n.adapter.locale = null;
-        i18n.translations = phrases;
+        i18n.languages = phrases;
+        i18n.culture = null;
       });
       it('should support pluralization with an integer', () => {
         expect(i18n.t('count_name', 2)).to.eql('2 Names');
@@ -113,18 +130,16 @@ describe('I18N with polyglot adapter', () => {
       const expectedUrl = 'alquiler/casa/marbella/ascensor';
 
       beforeEach(() => {
-        i18n.adapter.locale = 'es';
-        i18n.translations = urlTokens;
+        i18n.languages = urlTokens;
+        i18n.culture = 'es-ES';
       });
       afterEach(() => {
-        i18n.adapter.locale = null;
-        i18n.translations = phrases;
+        i18n.languages = phrases;
+        i18n.culture = null;
       });
       it('should translate all the tokens in a url', () => {
         expect(i18n.url(urlPattern)).to.eql(expectedUrl);
       });
-    })
+    });
   });
 });
-
-

--- a/test/translateSpec.js
+++ b/test/translateSpec.js
@@ -20,33 +20,6 @@ describe('I18N', () => {
     });
   });
 
-  describe('when change the translations', () => {
-    it('expect a notification for the event \"translations\" with the new dicc', (done) => {
-      const newTranslations = {key: 'llave'};
-      i18n.on(CHANGE_TRANSLATION_EVENT, (dicc) => {
-        expect(dicc).to.be.equal(newTranslations);
-        done();
-      });
-
-      i18n.translations = newTranslations;
-    });
-
-    it('we can change the translation in a silent mode', (done) => {
-      let silent = true;
-      i18n.on(CHANGE_TRANSLATION_EVENT, () => {
-        silent = false;
-      });
-
-      i18n.setTranslationsSilent({key: 'llave'}, 'es-ES');
-
-      setTimeout(() => {
-        expect(silent).to.be.true;
-        expect(i18n.culture).to.be.eq('es-ES');
-        done();
-      }, 50);
-    });
-  });
-
   describe('using the languages setting we change the culture', () => {
     let i18nCulture;
     beforeEach( () => {
@@ -89,6 +62,5 @@ describe('I18N', () => {
         expect(i18nCulture.t('literalOne')).to.eql('TranslateOneEnGB');
       });
     });
-
   });
 });


### PR DESCRIPTION
Hi guys, we basically removed deprecated methods on Rosetta since we've seen we can remove them safely.

There's another thing, that is to update all components docs files that uses the old implementation, but I think it would be a better approach to update them when needed.

@carlosvillu @danderu @FranDelaCasa please check it ;)