### PR TITLE
added underscore to improve the url translation method

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "webpack-dev-server": "1.14.0"
   },
   "dependencies": {
-    "node-polyglot": "0.4.3"
+    "node-polyglot": "0.4.3",
+    "underscore.string": "3.2.3"
   },
   "peerDependencies": {
     "react": "0.14"

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,7 +1,7 @@
 import {EventEmitter} from 'events';
 import DefaultAdapter from './adapters/default';
 import * as decorator from './decorator';
-import _ from 'underscore.string';
+import slugify from 'underscore.string/slugify';
 
 export const CHANGE_TRANSLATION_EVENT = 'translations';
 
@@ -40,7 +40,7 @@ export default class Rosetta extends EventEmitter {
 
   url(urlPattern) {
     return urlPattern.split('/').map((token) => {
-      return _.slugify(this.t(token));
+      return slugify(this.t(token));
     }).join('/');
   }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,6 +1,7 @@
 import {EventEmitter} from 'events';
 import DefaultAdapter from './adapters/default';
 import * as decorator from './decorator';
+import _ from 'underscore.string';
 
 export const CHANGE_TRANSLATION_EVENT = 'translations';
 
@@ -39,7 +40,7 @@ export default class Rosetta extends EventEmitter {
 
   url(urlPattern) {
     return urlPattern.split('/').map((token) => {
-      return this.t(token).toLowerCase();
+      return _.slugify(this.t(token));
     }).join('/');
   }
 

--- a/test/adapters/polyglotSpec.js
+++ b/test/adapters/polyglotSpec.js
@@ -126,9 +126,6 @@ describe('I18N with polyglot adapter', () => {
     });
 
     describe('url', () => {
-      const urlPattern = 'rent/house/marbella/elevator';
-      const expectedUrl = 'alquiler/casa/marbella/ascensor';
-
       beforeEach(() => {
         i18n.languages = urlTokens;
         i18n.culture = 'es-ES';
@@ -137,8 +134,23 @@ describe('I18N with polyglot adapter', () => {
         i18n.languages = phrases;
         i18n.culture = null;
       });
-      it('should translate all the tokens in a url', () => {
-        expect(i18n.url(urlPattern)).to.eql(expectedUrl);
+
+      describe('should translate url tokens', () => {
+        const urlPattern = 'rent/house/marbella/elevator';
+        const expectedUrl = 'alquiler/casa/marbella/ascensor';
+
+        it('simple translation', () => {
+          expect(i18n.url(urlPattern)).to.eql(expectedUrl);
+        });
+      });
+
+      describe('should remove uppercase, spaces and accents', () => {
+        const urlPattern = 'rent/house/Málaga Capital/elevator';
+        const expectedUrl = 'alquiler/casa/malaga-capital/ascensor';
+
+        it('dasherized and slugified', () => {
+          expect(i18n.url(urlPattern)).to.eql(expectedUrl);
+        });
       });
     });
   });


### PR DESCRIPTION
I've added a dependency of [underscore.string](https://github.com/epeli/underscore.string) in order to have methods to improve the url translation. With the usage of `slugify`, we now are able to

* remove accents
* replace spaces with dashes `-`
* lowercase all strings

This should made all the urls with accents or spaces work as expected in the SEO footer.

@ruben-martin-lozano @FranDelaCasa @carlosvillu @davecarter please review